### PR TITLE
Fix for baseline in different sized canvases. 

### DIFF
--- a/jquery.signaturepad.js
+++ b/jquery.signaturepad.js
@@ -226,8 +226,8 @@ function SignaturePad (selector, options) {
     canvasContext.beginPath()
     canvasContext.lineWidth = settings.lineWidth
     canvasContext.strokeStyle = settings.lineColour
-    canvasContext.moveTo(settings.lineMargin, settings.lineTop)
-    canvasContext.lineTo(element.width - settings.lineMargin, settings.lineTop)
+    canvasContext.moveTo(settings.lineMargin, element.height-settings.lineBottom)
+    canvasContext.lineTo(element.width - settings.lineMargin, element.height-settings.lineBottom)
     canvasContext.stroke()
     canvasContext.closePath()
   }
@@ -719,7 +719,7 @@ $.fn.signaturePad.defaults = {
   , lineColour: '#ccc' // Colour of the signature line
   , lineWidth: 2 // Thickness of the signature line
   , lineMargin: 5 // Margin on right and left of signature line
-  , lineTop: 35 // Distance to draw the line from the top
+  , lineBottom: 25 // Distance to draw the line from the bottom
   , name: '.name' // The input field for typing a name
   , typed: '.typed' // The Html element to accept the printed name
   , clear: '.clearButton' // Button for clearing the canvas


### PR DESCRIPTION
Switched lineTop to be lineBottom, so that if there is a canvas with a different size, the baseline will still be there.

Example CSS to change size of signature pad:

```
  .sigPad{
	  width:400px;
  }
  .sigWrapper{
	  height:100px;
	  width:400px;
  }
  canvas.pad{
	  height:100px;
	  width:398px;
  }

```

*Note:*
\<canvas\>es should still have width and height attributes, even if set through CSS, else it'll stretch all weird.

Thanks!