### PR TITLE
Fixed non-firing touch event for mobile touches

### DIFF
--- a/jquery.signaturepad.js
+++ b/jquery.signaturepad.js
@@ -398,7 +398,7 @@ function SignaturePad (selector, options) {
     // Closes open keyboards to free up space
     $('input').blur();
 
-    if (typeof e.targetTouches !== 'undefined')
+    if (typeof e.originalEvent.targetTouches !== 'undefined')
       touchable = true
 
     if (touchable) {
@@ -444,14 +444,14 @@ function SignaturePad (selector, options) {
     $(settings.typed, context).hide()
     clearCanvas()
 
-    canvas.each(function () {
-      this.ontouchstart = function (e) {
+    // canvas.each(function () {
+      canvas.on('touchstart', function (e) {
         e.preventDefault()
         mouseButtonDown = true
         initDrawEvents(e)
         startDrawing(e, this)
-      }
-    })
+      });
+    // })
 
     canvas.bind('mousedown.signaturepad', function (e) {
       e.preventDefault()
@@ -888,4 +888,4 @@ $.fn.signaturePad.defaults = {
   , onDrawEnd : null // Pass a callback to be exectued after the drawing process
 }
 
-}(jQuery));
+}(jQuery))

--- a/jquery.signaturepad.js
+++ b/jquery.signaturepad.js
@@ -444,14 +444,12 @@ function SignaturePad (selector, options) {
     $(settings.typed, context).hide()
     clearCanvas()
 
-    // canvas.each(function () {
-      canvas.on('touchstart', function (e) {
-        e.preventDefault()
-        mouseButtonDown = true
-        initDrawEvents(e)
-        startDrawing(e, this)
-      });
-    // })
+    canvas.on('touchstart', function (e) {
+      e.preventDefault()
+      mouseButtonDown = true
+      initDrawEvents(e)
+      startDrawing(e, this)
+    });
 
     canvas.bind('mousedown.signaturepad', function (e) {
       e.preventDefault()
@@ -888,4 +886,4 @@ $.fn.signaturePad.defaults = {
   , onDrawEnd : null // Pass a callback to be exectued after the drawing process
 }
 
-}(jQuery))
+}(jQuery));


### PR DESCRIPTION
When switching to mobile mode on Chrome, the touch event was not firing, as indicated by the event object in "drawIt()".  Instead, touches were being shot off as a "Mouse"-related event.

![screen shot 2014-11-23 at 1 30 39 am 2](https://cloud.githubusercontent.com/assets/3760499/5157226/8437ad6a-72b0-11e4-9d08-97920e1e3e91.png)
